### PR TITLE
naming wrapper function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const asyncUtil = fn =>
-(req, res, next, ...args) =>
-  fn(req, res, next, ...args)
+function asyncUtilWrap(req, res, next, ...args) {
+  return fn(req, res, next, ...args)
     .catch(next);
+}
 
 module.exports = asyncUtil


### PR DESCRIPTION
- the anonymous function shows up as `'args'` inside a stack trace, making
  it very hard to debug
- naming it properly fixes that

Assuming we have async stack traces turned on, here is the before and after we see in DevTools.

### Before the Change

![screen shot 2018-02-22 at 2 12 25 pm](https://user-images.githubusercontent.com/192891/36564883-0bdd4580-17dc-11e8-93cd-8a34bec987b2.png)

### After the Change

![screen shot 2018-02-22 at 2 15 39 pm](https://user-images.githubusercontent.com/192891/36564898-168045b4-17dc-11e8-8f6a-6ea6745395e1.png)

I tried to keep the change as small as possible. Functionality is not affected at all, we're just giving the v8 debugger a better hint on how to name the function :)