### PR TITLE
Don't throw when sync callback doesn't throw

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const asyncUtil = fn =>
 function asyncUtilWrap(req, res, next, ...args) {
-  return fn(req, res, next, ...args)
+  return Promise.resolve(fn(req, res, next, ...args))
     .catch(next);
 }
 

--- a/test.js
+++ b/test.js
@@ -20,6 +20,11 @@ describe('asyncUtil', () => {
     expect(foo).to.throw(error)
   })
 
+  it('should not throw an exception when a function passed into it does not throw one', async () => {
+    const foo = asyncUtil(() => {})
+    expect(foo).not.to.throw()
+  })
+
   it('should call next with the error when an async function passed into it throws', async () => {
     const error = new Error('catch me!')
     const next = sinon.spy();


### PR DESCRIPTION
Related to https://github.com/Abazhenov/express-async-handler/issues/12