### PR TITLE
accept non-Promises without breaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 const asyncUtil = fn =>
 function asyncUtilWrap(req, res, next, ...args) {
-  const fnReturn = fn(req, res, next, ...args)
-  if (fnReturn instanceof Promise) {
-    return fnReturn.catch(next)
+  if (fn instanceof Promise) {
+    return fn(req, res, next, ...args).catch(next)
   } else {
-    return fnReturn
+    return fn(req, res, next, ...args)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 const asyncUtil = fn =>
 function asyncUtilWrap(req, res, next, ...args) {
-  return fn(req, res, next, ...args)
-    .catch(next);
+  const fnReturn = fn(req, res, next, ...args)
+  if (fnReturn instanceof Promise) {
+    return fnReturn.catch(next)
+  } else {
+    return fnReturn
+  }
 }
 
 module.exports = asyncUtil

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ chai.should()
 const asyncUtil = require('./index')
 
 describe('asyncUtil', () => {
-  
+
   it('should catch exceptions of a function passed into it', async () => {
     const error = new Error('catch me!')
     const foo = asyncUtil(() => {
@@ -52,4 +52,24 @@ describe('asyncUtil', () => {
     expect(result).to.equal(id);
   })
 
+  it('should accept a non-async function', async () => {
+    const next = sinon.spy()
+    const foo = asyncUtil((req, res, next) => {
+      next('test')
+    })
+
+    await foo(null, null, next)
+    expect(next).to.have.been.calledWith('test')
+  })
+
+  it('should accept a non-async function erroring', async () => {
+    const error = new Error('catch me!')
+    const next = sinon.spy();
+    const foo = asyncUtil((req, res, next) => {
+      next(error)
+    })
+
+    await foo(null, null, next)
+    expect(next).to.have.been.calledWith(error)
+  })
 })


### PR DESCRIPTION
Test results without this code change:
```
  asyncUtil
    ✓ should catch exceptions of a function passed into it
    ✓ should call next with the error when an async function passed into it throws
    ✓ should call next with the arguments when an async function passed into it calls next
    ✓ should provide additional arguments to the middleware
    1) should accept a non-async function
    2) should accept a non-async function erroring


  4 passing (11ms)
  2 failing

  1) asyncUtil
       should accept a non-async function:
     TypeError: Cannot read property 'catch' of undefined
      at asyncUtilWrap (index.js:4:5)
      at Context.it (test.js:61:11)

  2) asyncUtil
       should accept a non-async function erroring:
     TypeError: Cannot read property 'catch' of undefined
      at asyncUtilWrap (index.js:4:5)
      at Context.it (test.js:72:11)
```