### PR TITLE
TS typing for async handler function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,8 @@
-declare module 'express-async-handler'
+import express = require('express');
+
+declare function expressAsyncHandler(handler: express.RequestHandler): express.RequestHandler;
+declare namespace expressAsyncHandler {
+
+}
+
+export = expressAsyncHandler;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   ],
   "author": "Alex Bazhenov",
   "license": "MIT",
+  "dependencies": {
+    "@types/express": "*"
+  },
   "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^5.0.0",


### PR DESCRIPTION
This adds TS type checks to the async handler function. This makes sure that:

1. `asyncHandler('foo')` results in a compile error,
2. for `asyncHandler((req, res, next) => { … })`, the `req`, `res`, and `next` arguments retain their typing (before this PR, they were just typed `any`, which defeats a great portion of the TS benefits)