### PR TITLE
Move @types/express to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,8 @@
   ],
   "author": "Alex Bazhenov",
   "license": "MIT",
-  "dependencies": {
-    "@types/express": "*"
-  },
   "devDependencies": {
+    "@types/express": "*",
     "chai": "^4.1.2",
     "mocha": "^5.0.0",
     "sinon": "^4.2.1",


### PR DESCRIPTION
Apologies, after #18 I've noticed that `@types/express` should be in `devDependencies`, else wise builds might fail (interestingly, it only happened with yarn here in our environment).

Sorry for any inconvenience and would be glad to get this merged asap :-)