### PR TITLE
README.md update for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ express.get('/', asyncHandler(async (req, res, next) => {
 #### Import in Typescript:
 
 ```javascript
-import * as asyncHandler from 'express-async-handler'
+import asyncHandler from 'express-async-handler'
 ```


### PR DESCRIPTION
Updated to the proper import for TypeScript for this module format. Using "import * as asyncHandler ..."  will result in warning "Cannot Invoke an Expression whose Type Lacks a Call Signature"  and compile to TypeError: asyncHandler is not a function