### PR TITLE
Handle sync errors in the middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const asyncUtil = fn =>
 function asyncUtilWrap(req, res, next, ...args) {
-  const fnReturn = fn(req, res, next, ...args)
-  return Promise.resolve(fnReturn).catch(next)
+  return new Promise(function (resolve) {
+    resolve(fn(req, res, next, ...args));
+  }).catch(next);
 }
 
 module.exports = asyncUtil

--- a/test.js
+++ b/test.js
@@ -12,12 +12,14 @@ const asyncUtil = require('./index')
 
 describe('asyncUtil', () => {
 
-  it('should catch exceptions of a function passed into it', async () => {
+  it('should call next with the error when a function passed into it throws', async () => {
     const error = new Error('catch me!')
+    const next = sinon.spy();
     const foo = asyncUtil(() => {
       throw error
     })
-    expect(foo).to.throw(error)
+    await foo(null, null, next)
+    expect(next).to.have.been.calledWith(error)
   })
 
   it('should call next with the error when an async function passed into it throws', async () => {


### PR DESCRIPTION
Currently synchronous errors are not handled by the middleware.
I wasn't sure if it was by design or an oversight.
When `fn` threw synchronously, `asyncUtilWrap` wouldn't return a Promise at all.

It's fixed in this PR. The fix uses the idea from the `Promise.try` draft proposal.

It's a breaking change.