### PR TITLE
Error-handling middleware support (Fixes #22)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const asyncUtil = fn =>
-function asyncUtilWrap(req, res, next, ...args) {
-  const fnReturn = fn(req, res, next, ...args)
+function asyncUtilWrap(...args) {
+  const fnReturn = fn(...args)
+  const next = args[args.length-1]
   return Promise.resolve(fnReturn).catch(next)
 }
 


### PR DESCRIPTION
This solution is meant to fix issue #22 and it assumes that `next` is always the last argument.