### PR TITLE
Updated TypeScript import

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ express.get('/', asyncHandler(async (req, res, next) => {
 #### Import in Typescript:
 
 ```javascript
-import * as asyncHandler from 'express-async-handler'
+import asyncHandler from "express-async-handler"
 ```


### PR DESCRIPTION
I'm pretty sure somewhere along the way you guys changed how the middleware is exported and your old TypeScript import syntax no longer works. I updated the README file with the import that works with the current version (as that is what has worked in my current project).

It might be a relevant that I'm on (current) TypeScript 3.1.6.