### PR TITLE
docs: change 'without express-async-handler' syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,10 @@ express.get('/', asyncHandler(async (req, res, next) => {
 Without express-async-handler
 
 ```javascript
-express.get('/',(req, res, next) => {
-    foo.findAll()
-    .then ( bar => {
-       res.send(bar)
-     } )
-    .catch(next); // error passed on to the error handling route
-})
+express.get('/', async (req, res, next) => {
+	const bar = await foo.findAll();
+	res.send(bar)
+}).catch(next)
 ```
 
 #### Import in Typescript:


### PR DESCRIPTION
Reason for this pull request is to provide a better/closer syntax to the 'without express-async-handler' syntax.
The current one uses .then instead of async/await, which makes it look more verbose / less clean.