### PR TITLE
Improve TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,14 @@
 import express = require('express');
+import core = require('express-serve-static-core');
 
-declare function expressAsyncHandler<R extends express.RequestHandler>(handler: (...args: Parameters<R>) => void | Promise<void>): R;
+declare function expressAsyncHandler<
+  P = core.ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = core.Query,
+>(handler: (...args: Parameters<express.RequestHandler<P, ResBody, ReqBody, ReqQuery>>) => void | Promise<void>):
+  express.RequestHandler<P, ResBody, ReqBody, ReqQuery>;
+
 declare namespace expressAsyncHandler {
 
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import express = require('express');
 
-declare function expressAsyncHandler(handler: (...args: Parameters<express.RequestHandler>) => void | Promise<void>): express.RequestHandler;
+declare function expressAsyncHandler<R extends express.RequestHandler>(handler: (...args: Parameters<R>) => void | Promise<void>): R;
 declare namespace expressAsyncHandler {
 
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import express = require('express');
 
-declare function expressAsyncHandler(handler: express.RequestHandler): express.RequestHandler;
+declare function expressAsyncHandler(handler: (...args: Parameters<express.RequestHandler>) => void | Promise<void>): express.RequestHandler;
 declare namespace expressAsyncHandler {
 
 }


### PR DESCRIPTION
These TS typing improvements address the following:

* Consider that usually a `Promise` is passed to the `expressAsyncHandler` function. Without this fix newer ESLint versions will produce the following error:

   ```
   Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
   ```

* Pass Express’ generics for `P`, `ResBody`, `ReqBody`, and `ReqQuery` to the wrapped handler function. This provides an additional level of type-safety if being used:

   ```typescript
   const handler = async (
     req: express.Request<{ foo: string; bar: number }>,
     res: express.Response
   ): Promise<void> => {
      // req.params.foo is string
      // req.params.bar is number
      // ...
   };

   router.get<{ foo: string; bar: number }>('/:foo/:bar', asyncHandler(handler));
   // gives error:
   router.get<{ foo: string; bar: string }>('/:foo/:bar', asyncHandler(handler));
   ```