### PR TITLE
Add @types/express as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   ],
   "author": "Alex Bazhenov",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "@types/express": "*",
+  },
+  "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^5.0.0",
     "sinon": "^4.2.1",


### PR DESCRIPTION
The types [include `import express = require('express');`](https://github.com/Abazhenov/express-async-handler/blob/ccd9b5b9b0bbe853ec3374cb76ee0d7b81b736a3/index.d.ts#L1), so `@types/express` should be declared as a `dependency` in `package.json`, [not as a `devDependency`](https://github.com/Abazhenov/express-async-handler/blob/ccd9b5b9b0bbe853ec3374cb76ee0d7b81b736a3/package.json#L24). See the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies) for reasoning. I can’t use `express-async-handler` because of this.