### PR TITLE
fix: Add missing typings for express response Locals

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,9 @@ declare function expressAsyncHandler<
   ResBody = any,
   ReqBody = any,
   ReqQuery = core.Query,
->(handler: (...args: Parameters<express.RequestHandler<P, ResBody, ReqBody, ReqQuery>>) => void | Promise<void>):
-  express.RequestHandler<P, ResBody, ReqBody, ReqQuery>;
+  Locals extends Record<string, any> = Record<string, any>
+>(handler: (...args: Parameters<express.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>) => void | Promise<void>):
+  express.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>;
 
 declare namespace expressAsyncHandler {
 


### PR DESCRIPTION
Express `RequestHandler` has a fifth generic `Locals` that controls the typing of the `res.locals` property.

With the current version of express-async-handler it's impossible to pass that generic.

```ts
interface MyLocals {
  something: number;
}

router.get('test', expressAsyncHandler(async (req, res: Response<any, MyLocals>) => {
    res.locals.something = 5;
    res.locals.somethingElse = 6;
  })
);
```
Without this fix it shows an error:
![image](https://user-images.githubusercontent.com/498419/144245658-b463a953-caba-4639-997b-9685ff26a215.png)

```
Argument of type '(req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, MyLocals>) => Promise<...>' is not assignable to parameter of type '(req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>, number>, next: NextFunction) => void | Promise<...>'.
  Types of parameters 'res' and 'res' are incompatible.
    Type 'Response<any, Record<string, any>, number>' is not assignable to type 'Response<any, MyLocals>'.
      Types of property 'locals' are incompatible.
        Property 'something' is missing in type 'Record<string, any>' but required in type 'MyLocals'.ts(2345)
```

With the Locals generic it works as expected
![image](https://user-images.githubusercontent.com/498419/144245824-8afdeeb0-f60d-4df7-a96d-416f02c53156.png)
