### PR TITLE
Improve types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import express = require('express');
 import core = require('express-serve-static-core');
 
 declare function expressAsyncHandler<
-  P = core.ParamsDictionary,
+  P extends core.Params = core.ParamsDictionary,
   ResBody = any,
   ReqBody = any,
   ReqQuery = core.Query,


### PR DESCRIPTION
With the newest eslint version we currently get the error `Type 'P' does not satisfy the constraint 'Params'. Type 'P' is not assignable to type 'ParamsArray'.`.
This is fixed with this PR by extending the `core.Params` like it is in the express type of `P`.