### PR TITLE
Add Locals type in RequestHandler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,9 @@ declare function expressAsyncHandler<
   ResBody = any,
   ReqBody = any,
   ReqQuery = core.Query,
->(handler: (...args: Parameters<express.RequestHandler<P, ResBody, ReqBody, ReqQuery>>) => void | Promise<void>):
-  express.RequestHandler<P, ResBody, ReqBody, ReqQuery>;
+  Locals = any
+>(handler: (...args: Parameters<express.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>) => void | Promise<void>):
+  express.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>;
 
 declare namespace expressAsyncHandler {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-async-handler",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Express Error Handler for Async Functions",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
If your request handler uses the `Locals` field in the response object, you won't be able to use this library with Typescript. This fixes that.