### PR TITLE
fix: handler return typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare function expressAsyncHandler<
   ResBody = any,
   ReqBody = any,
   ReqQuery = core.Query,
->(handler: (...args: Parameters<express.RequestHandler<P, ResBody, ReqBody, ReqQuery>>) => void | Promise<void>):
+>(handler: (...args: Parameters<express.RequestHandler<P, ResBody, ReqBody, ReqQuery>>) => void | Promise<void> | core.Response | Promise<core.Response> ):
   express.RequestHandler<P, ResBody, ReqBody, ReqQuery>;
 
 declare namespace expressAsyncHandler {


### PR DESCRIPTION
Adding handler return typings `core.Response | Promise<core.Response>`. 
This fixed the issue where the handler had `return res.status(200).json(anyres)`

something like this
```
route.get(
  '/route',
  AsyncHandler(async function getAll(
    req: Request,
    res: Response
  ): Promise<Response> {
    ...
    return res.status(200).json(httpRes)
  })
)
```